### PR TITLE
Add gradient and border color to HP bar

### DIFF
--- a/README.dist.md
+++ b/README.dist.md
@@ -37,4 +37,4 @@ You should have received a [copy](LICENSE.txt) of the GNU Affero General Public 
 
 ### pso-icons
 
-The [pso-icons](https://github.com/akdb/pso-icons) are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+SVG assets in this repository and the [pso-icons](https://github.com/akdb/pso-icons) are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ You should have received a [copy](LICENSE.txt) of the GNU Affero General Public 
 
 ### pso-icons
 
-The [pso-icons](https://github.com/akdb/pso-icons) are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+SVG assets in this repository and the [pso-icons](https://github.com/akdb/pso-icons) are licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/src/assets/hp.svg
+++ b/src/assets/hp.svg
@@ -1,3 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
-<rect x="0" y="40" width="100" height="20" rx="5" ry="5" fill="#0bb735" stroke="#000" stroke-miterlimit="10"/>
+<defs>
+    <linearGradient id="fill"
+        x1="0%" y1="0%" x2="0%" y2="100%"
+    >
+        <stop offset="14.28%" stop-color="#00980c" />
+        <stop offset="28.57%" stop-color="#00cc10" />
+        <stop offset="42.86%" stop-color="#00ff14" />
+        <stop offset="57.14%" stop-color="#00ee13" />
+        <stop offset="71.43%" stop-color="#00bc0f" />
+        <stop offset="85.71%" stop-color="#007109" />
+        <stop offset="100%" stop-color="#003204" stop-opacity="0.573" />
+    </linearGradient>
+</defs>
+<rect x="3" y="40" width="94" height="20"
+    rx="7"
+    fill="url(#fill)"
+    stroke="#45777c" stroke-width="3"
+/>
 </svg>

--- a/src/assets/hp.svg
+++ b/src/assets/hp.svg
@@ -25,7 +25,7 @@
         <stop offset="87.5%" stop-color="#003204" stop-opacity="0.573" />
     </linearGradient>
 </defs>
-<rect x="3" y="40" width="94" height="20"
+<rect x="3" y="44" width="94" height="12"
     rx="7"
     fill="url(#fill)"
     stroke="#45777c" stroke-width="3"

--- a/src/assets/hp.svg
+++ b/src/assets/hp.svg
@@ -1,4 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 100"
+    xmlns:cc="http://creativecommons.org/ns#"
+>
+<metadata typeof="cc:Work">
+    This work, from
+    <a property="cc:attributionName" rel="cc:attributionURL"
+        href="https://github.com/akdb/pso-tracker"
+    >
+    pso-tracker</a>, is licensed under a
+    <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+        Creative Commons Attribution-ShareAlike 4.0 International License
+    </a>.
+</metadata>
 <defs>
     <linearGradient id="fill"
         x1="0%" y1="0%" x2="0%" y2="100%"

--- a/src/assets/hp.svg
+++ b/src/assets/hp.svg
@@ -16,13 +16,13 @@
     <linearGradient id="fill"
         x1="0%" y1="0%" x2="0%" y2="100%"
     >
-        <stop offset="14.28%" stop-color="#00980c" />
-        <stop offset="28.57%" stop-color="#00cc10" />
-        <stop offset="42.86%" stop-color="#00ff14" />
-        <stop offset="57.14%" stop-color="#00ee13" />
-        <stop offset="71.43%" stop-color="#00bc0f" />
-        <stop offset="85.71%" stop-color="#007109" />
-        <stop offset="100%" stop-color="#003204" stop-opacity="0.573" />
+        <stop offset="12.5%" stop-color="#00980c" />
+        <stop offset="25%" stop-color="#00cc10" />
+        <stop offset="37.5%" stop-color="#00ff14" />
+        <stop offset="50%" stop-color="#00ee13" />
+        <stop offset="62.5%" stop-color="#00bc0f" />
+        <stop offset="75%" stop-color="#007109" />
+        <stop offset="87.5%" stop-color="#003204" stop-opacity="0.573" />
     </linearGradient>
 </defs>
 <rect x="3" y="40" width="94" height="20"

--- a/src/assets/hp.svg
+++ b/src/assets/hp.svg
@@ -24,10 +24,16 @@
         <stop offset="75%" stop-color="#007109" />
         <stop offset="87.5%" stop-color="#003204" stop-opacity="0.573" />
     </linearGradient>
+    <linearGradient id="stroke"
+        x1="0%" y1="0%" x2="0%" y2="100%"
+    >
+        <stop offset="0%" stop-color="#2da0b2" />
+        <stop offset="100%" stop-color="#41aab1" />
+    </linearGradient>
 </defs>
 <rect x="3" y="44" width="94" height="12"
     rx="7"
     fill="url(#fill)"
-    stroke="#45777c" stroke-width="3"
+    stroke="url(#stroke)" stroke-width="2"
 />
 </svg>


### PR DESCRIPTION
## What does this pull request change?
* Fixes #5
* Use gradient and approximate border color for HP bar
* Release hp.svg under CC-BY-SA

## To-Do
- [x] get a better fix on the color to use

## Testing
- [x] see screenshots below

![image](https://user-images.githubusercontent.com/20408541/58523864-9dd61100-818b-11e9-908f-b83802a48548.png) ![image](https://user-images.githubusercontent.com/20408541/58523920-d4ac2700-818b-11e9-81e7-21864a4737f3.png) ![image](https://user-images.githubusercontent.com/20408541/58523962-08874c80-818c-11e9-96b6-a873df5e472c.png)
