### PR TITLE
Improve visibility of values

### DIFF
--- a/src/modules/Trackables.js
+++ b/src/modules/Trackables.js
@@ -95,7 +95,6 @@ let Trackables = {
         'image': slots,
         'imageWidth': 40,
         'imageHeight': 40,
-        'imageOffsetY': -5,
         'description': 'Frame Slots',
     },
     'barrier': {
@@ -103,7 +102,6 @@ let Trackables = {
         'image': barrier,
         'imageWidth': 40,
         'imageHeight': 40,
-        'imageOffsetY': -5,
         'description': 'Barrier Obtained?',
     }
 };

--- a/src/tracker.css
+++ b/src/tracker.css
@@ -166,6 +166,7 @@ text.increment.highlight
 {
     fill: black;
     stroke: black;
+    stroke-width: 5;
     filter: url(#glow);
 }
 

--- a/src/tracker.css
+++ b/src/tracker.css
@@ -113,7 +113,8 @@ g.hybrid text.value
 /* Non-hybrid palettes: Put the value at the bottom of the cell instead */
 g:not(.hybrid) > g text.value
 {
-    transform: translate(0,31px);
+    text-anchor: end;
+    transform: translate(21px,32px);
 }
 
 /* Display parameters for the key control display */


### PR DESCRIPTION
## What does this pull request change?
* Fixes #3 
* Adds extra thickness to the "glow" text to make sure there is enough contrast at low resolutions and bitrates
* Moves text to the corner to move it to its own space a bit more and away from problematic bright icons like Zonde

## Testing
- [x] tested all palette configurations
![image](https://user-images.githubusercontent.com/20408541/58835020-6992a280-861a-11e9-949f-0bb9ac2e368c.png)

## Feedback
- [x] Does intentionally putting text shadows outside of the cell look okay?