### PR TITLE
Start Barta at level 1 for Forces

### DIFF
--- a/src/modules/Model.js
+++ b/src/modules/Model.js
@@ -125,7 +125,7 @@ export default class Model {
     ResetValues() {
         this._values = {};
         for (const trackKey of Object.keys(this.trackables)) {
-            let initialValue = this.GetAttribute(trackKey, 'min', 0);
+            let initialValue = this.GetAttribute(trackKey, 'initial', this.GetAttribute(trackKey, 'min', 0));
 
             // populate this key as a valid key
             this._values[trackKey] = initialValue;

--- a/src/modules/PaletteProfiles.js
+++ b/src/modules/PaletteProfiles.js
@@ -37,7 +37,10 @@ let PaletteProfiles = {
         'name': 'Episode 1 Glitchless Any% FOnewm',
         'trackables': {
             'foie': { 'min': 1 },
-            'barta': { 'target': 1 },
+            'barta': {
+                'target': 1,
+                'initial': 1,
+            },
             'zonde': { 'target': 1 },
             'gifoie': {
                 'target': 1,
@@ -96,7 +99,10 @@ let PaletteProfiles = {
         'name': "Episode 1 Glitchless Any% FOnewearl",
         'trackables': {
             'foie': { 'min': 1 },
-            'barta': { 'target': 1 },
+            'barta': {
+                'target': 1,
+                'initial': 1,
+            },
             'zonde': { 'target': 1 },
             'gifoie': {
                 'target': 1,


### PR DESCRIPTION
## What does this pull request change?
* Fixes #2 
* Start Barta at level 1 because you usually can and will buy it and often will reset without it (but it is not strictly necessary)
* Add support for trackables to have initial values other than their minimum

## Testing
- [x] observed that barta does indeed start at 1 after reset but can be subtracted
- [x] tested with fresh save data
