### PR TITLE
Fix window restore dimensions to be consistent with Revert Window Size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,15 @@ window.onload = () => {
                 windowFeatures += `,width=${adjustedWidth},height=${adjustedHeight}`;
             }
         }
-        window.open('tracker.html?' + new URLSearchParams(new FormData(form)).toString(), 'pso-tracker', windowFeatures);
+        let newWindow = window.open('tracker.html?' + new URLSearchParams(new FormData(form)).toString(), 'pso-tracker', windowFeatures);
+
+        /**
+         * this force resize is to address inconsistencies in Firefox not quite calculating the difference between
+         * inner and outer height correctly
+         */
+        if (config.windowWidth && config.windowHeight)
+            newWindow.resizeTo(config.windowWidth, config.windowHeight);
+
         event.preventDefault();
         return false;
     };

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,9 @@ window.onload = () => {
         if (saveContainer.Load()) {
             config = saveContainer.data.configuration;
             if (config && config.windowWidth > 0 && config.windowHeight > 0) {
-                windowFeatures += `,width=${config.windowWidth},height=${config.windowHeight}`;
+                let adjustedWidth = config.windowWidth - config.windowWidthMargin || 0;
+                let adjustedHeight = config.windowHeight - config.windowHeightMargin || 0;
+                windowFeatures += `,width=${adjustedWidth},height=${adjustedHeight}`;
             }
         }
         window.open('tracker.html?' + new URLSearchParams(new FormData(form)).toString(), 'pso-tracker', windowFeatures);

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -232,6 +232,8 @@ window.onload = () => {
     document.getElementById('saveWindowSize').onclick = () => {
         saveContainer.data.configuration.windowWidth = window.outerWidth;
         saveContainer.data.configuration.windowHeight = window.outerHeight;
+        saveContainer.data.configuration.windowWidthMargin = window.outerWidth - window.innerWidth;
+        saveContainer.data.configuration.windowHeightMargin = window.outerHeight - window.innerHeight;
         saveContainer.Save();
     };
 


### PR DESCRIPTION
## What does this pull request change?
* Fixes #8
* Calculate difference between outer and inner window sizes to restore window size correctly
  * `window.open` features ask for inner dimensions, `but window.resizeTo` asks for outer dimensions
  * Unfortunately, Firefox apparently has an inconsistency between `window.open` with calculated height/width and `window.resizeTo`, while Chrome does not, so we'll just call `resizeTo` directly after making the window to make the subtle fix

## Testing
- [x] tested save/revert/launch in Chrome
- [x] tested save/revert/launch in Firefox