### PR TITLE
Issue #13: Enable keyboard controls for the 'view-only-mouse' configuration

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
                                 Combine controls and display (1 palette)
                             </option>
                             <option value="view-only-mouse">
-                                Display palette only (mouse controls only)
+                                Display palette only (mouse enabled)
                             </option>
                             <option value="view-only-keys">
                                 Display palette only (key controls only)

--- a/src/modules/Palette.js
+++ b/src/modules/Palette.js
@@ -223,7 +223,7 @@ export default class Palette {
      */
     RenderCellControls() {
         for (const [trackKey, cell] of Object.entries(this.cells)) {
-            cell.on('click', () => this.model.IncrementValue(trackKey, this.GetInputLevel(trackKey), 1));
+            cell.on('click', () => this.model.IncrementValue(trackKey, this.GetInputLevel(trackKey), this.GetInputFactor()));
             cell.on('contextmenu', event => {
                 this.model.IncrementValue(trackKey, this.GetInputLevel(trackKey), -1);
                 event.preventDefault();
@@ -462,7 +462,7 @@ export default class Palette {
     }
 
     /**
-     * Get the input factor that will be applied when pressing a control in a cell
+     * Get the input factor that will be applied when pressing a control in a cell (e.g. 1 or -1 to add or subtract values)
      * @return {number} 1 if not associated with a {@link KeyController}, else see {@link KeyController.GetInputFactor}
      */
     GetInputFactor() {

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -114,7 +114,7 @@ let hybridFeatures = {
  * Palette options used when view-only-mouse mode is chosen.
  * @type {PaletteOptions}
  */
-let mouseOnlyFeatures = {
+let mouseEnabledFeatures = {
     displayValue: true,
     outerEdge: true,
     cellControls: true,
@@ -185,7 +185,7 @@ window.onload = () => {
             paletteFeatures[0] = hybridFeatures;
             break;
         case 'view-only-mouse':
-            paletteFeatures[0] = mouseOnlyFeatures;
+            paletteFeatures[0] = mouseEnabledFeatures;
             break;
         case 'view-only-keys':
             paletteFeatures[0] = separateViewFeatures;

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -174,11 +174,8 @@ window.onload = () => {
     saveContainer.data.configuration.background = params.get('background');
     saveContainer.data.configuration.view = params.get('view');
 
-    let keyController = null;
-    if (params.get('view') != 'view-only-mouse') {
-        keyController = new KeyController(model);
-        keyController.Initialize(activeProfile.layouts[saveContainer.data.configuration.layout]);
-    }
+    let keyController = new KeyController(model);
+    keyController.Initialize(activeProfile.layouts[saveContainer.data.configuration.layout]);
 
     let paletteFeatures = [null, null];
     let paletteContainers = [inputRoot, mainRoot];


### PR DESCRIPTION
## What does this pull request change?
* Fixes #13 
* Allow use of keyboard controls on the mouse-control-enabled palette (even though keyboard shortcuts are not displayed)

## To-Do
- [x] make shift key act consistently (should subtract on left click just like alt/ctrl is applied on left click)
- [x] the displayed name shouldn't be "mouse controls only"

## Testing
- [x] tested for functionality of keyboard and mouse controls on the view-only-mouse palette
- [x] tested shift key for consistent functionality
