### PR TITLE
Issue #43: Reenable keyboard controls except for Browser Source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pso-tracker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "",
   "browser": "index.html",

--- a/src/modules/KeyController.js
+++ b/src/modules/KeyController.js
@@ -102,9 +102,9 @@ export default class KeyController {
      * @return {undefined}
      */
     OnKeyDown(event) {
-        if (document.getElementById('ctrlAssist').style.display != 'none')
-            return;
         if (this._codeToTrackableMap === null)
+            return;
+        if (document.getElementById('saveWindowSize').style.display == 'none') //browser source mode, disable actual key use due to apparent OBS bugs
             return;
 
         this._inputLevel = 0;
@@ -145,7 +145,7 @@ export default class KeyController {
     OnKeyUp(event) {
         if (this._codeToTrackableMap === null)
             return;
-        if (document.getElementById('ctrlAssist').style.display != 'none')
+        if (document.getElementById('saveWindowSize').style.display == 'none') //browser source mode, disable actual key use due to apparent OBS bugs
             return;
 
         let shift = event.code.startsWith('Shift');


### PR DESCRIPTION
## What does this pull request change?
- Fixes #43 : an untested/incomplete thought with disabling Browser Source keyboard controls
  - see #44

## Testing
- [x] tested keys worked outside of browser source, but not inside